### PR TITLE
used `typeof` to detect if variable is a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const clone = src => {
   if (
     !src ||
     typeof src !== 'object' ||
-    Object.prototype.toString.call(src) === '[object Function]'
+    typeof src === 'function'
   ) {
     return src
   }


### PR DESCRIPTION
accroding to this [test](https://jsperf.com/variable-type-detection-for-function) `typeof` is faster than `Object.prototype.toString.call()` when it comes to detecting functions

tested on FireFox, Chrome and Safari