### PR TITLE
Added module entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ report
 coverage
 npm-debug*
 .vscode
+index.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "290B to deep clone JavaScript objects",
   "license": "MIT",
   "main": "index.js",
+  "module": "src/index.js",
   "keywords": [
     "clone",
     "deep",
@@ -23,9 +24,12 @@
     "name": "Anton Kosykh"
   },
   "scripts": {
+    "build": "rollup -c",
     "lint": "eslint src/*.js test/*.js",
+    "pretest": "npm run build",
     "test": "jest --coverage && npm run lint",
-    "size": "size-limit"
+    "size": "size-limit",
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "eslint": "^4.11.0",
@@ -36,6 +40,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^21.2.1",
     "jsdom": "^11.4.0",
+    "rollup": "^0.53.3",
     "size-limit": "^0.13.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,9 @@
+import pkg from './package.json'
+
+export default {
+  input: pkg.module,
+  output: {
+    file: pkg.main,
+    format: 'cjs'
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-module.exports = function clone (src) {
+export default function clone (src) {
   // Null/undefined/functions/etc
   if (
     !src ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -4120,6 +4120,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rollup@^0.53.3:
+  version "0.53.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.3.tgz#e7b6777623df912bd0ca30dc24be791d6ebc8e5a"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"


### PR DESCRIPTION
Just presenting what I meant in comments under your article on the example :)

Summary of `main` entry (`./index.js` in a commonjs format)
Pre PR - 145 B
Post PR - 155 B
Post PR without `"use strict";` (can be disabled in rollup) - 146 B

Potentially strict mode is desired (it might even cause node to perform a little bit better), but I'm not sure how do you feel about those extra 10 B.